### PR TITLE
1week 문제풀이

### DIFF
--- a/1WEEK/10026-leeshinyook.java
+++ b/1WEEK/10026-leeshinyook.java
@@ -1,0 +1,67 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.*;
+import java.util.*;
+
+public class Main {
+    static String[][] arr = new String[101][101];
+    static boolean[][] check = new boolean[101][101];
+    static int[] dx = {0, 0, 1, -1};
+    static int[] dy = {-1, 1, 0, 0};
+    static int T, count, count2;
+    public static void main(String[] args) throws IOException {
+        Scanner sc = new Scanner(System.in);
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        T = Integer.parseInt(br.readLine());
+        count = 0;
+        count2 = 0;
+        for(int i = 0; i < T; i++) {
+            String[] input = br.readLine().split("");
+            for(int j = 0; j < T; j++) {
+                arr[i][j] = input[j];
+            }
+        }
+        // 정상
+        for(int i = 0; i < T; i++) {
+            for(int j = 0; j < T; j++) {
+                if(!check[i][j]) {
+                    count++;
+                    DFS(i, j);
+                }
+            }
+        }
+        // 적록색약
+        for(int i = 0; i < T; i++) {
+            for(int j = 0; j < T; j++) {
+                if(arr[i][j].equals("R")) {
+                    arr[i][j] = "G";
+                }
+                check[i][j] = false; // 초기화
+            }
+        }
+        for(int i = 0; i < T; i++) {
+            for(int j = 0; j < T; j++) {
+                if(!check[i][j]) {
+                    count2++;
+                    DFS(i, j);
+                }
+            }
+        }
+        System.out.print(count + " " + count2);
+
+    }
+    public static void DFS(int x, int y) {
+        check[x][y] = true;
+        String c = arr[x][y];
+        for(int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+            if(0 <= nx && nx < T && 0 <= ny && ny < T) {
+                if(arr[nx][ny].equals(c) && !check[nx][ny]) {
+                    DFS(nx, ny);
+                }
+            }
+        }
+    }
+}

--- a/1WEEK/2482-leeshinyook.cpp
+++ b/1WEEK/2482-leeshinyook.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <climits>
+#include <cstring>
+#include <algorithm>
+#include <math.h>
+#include <map>
+#include <set>
+const int mod = 1000000003;
+using namespace std;
+
+int dp[1001][1001];
+int N, K;
+int main(){
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cin >> N;
+    cin >> K;
+    for(int i = 0; i <= N; i++) {
+        dp[i][0] = 0;
+        dp[i][1] = i;
+    }
+    for(int i = 2; i <= N; i++) {
+        for(int j = 2; j <= K; j++) {
+            dp[i][j] = (dp[i - 1][j] + dp[i - 2][j - 1]) % mod;
+        }
+    }
+    int answer = (dp[N - 3][K - 1] + dp[N - 1][K]) % mod;
+    cout << answer;
+
+}
+


### PR DESCRIPTION
## 문제에서의 시간복잡도
- 적록색약
나는 DFS를 이용해서 문제를 해결했는데,  우선 두가지 1. 정상, 2. 비정상을 구분해서 DFS를 돌렸음.
이중포문을 돌렸기때문에, 시간복잡도는 O(N^2)이 될 것이지만, 최고로 들어갈 수 있는 수가 100까지니 시간제한 1초를 무난하게 통과할 것.
근데 DFS의 depth가 4000번 이상이면 재귀호출이 깊어지면서 시간초과가 날 수 있음. 
- 색상환
최악의 경우 N=1000, K=1000 O(N^2) 10^6번의 계산 N^2일 경우, 약 N이 10000개까지 커버가능.


## 어떤 로직이 핵심이었나?
- 적록색약
그냥 전형적인 DFS, BFS문제였고 상하좌우를 확인할 수 있는 
``` java
    static int[] dx = {0, 0, 1, -1};
    static int[] dy = {-1, 1, 0, 0};
```
이게 포인트였음. 매우 자주 쓰이는 패턴
- 색상환
다이나믹 프로그래밍 답게, 매 케이스마다 새로 계산하면 시간초과가 날 것이고, 배열에 담아서 이전꺼를 활용해줘야 시간제한을 피해갈 수 있음.
dp[i][j] = i개의 색이 있을 때, j개의 색을 선택할 수 있는 경우의 수.
다이나믹프로그래밍이라고 볼 수 있는데, `dp[i][j] = (dp[i - 1][j] + dp[i - 2][j - 1]) % mod;` 이게 이 문제에서의 점화식이었음.
그냥 원이 아니라, 선형적으로 생각했고 예를들어, 마지막 색(n)을 선택하게 되면, n - 1번째 색은 선택할 수 없고 이전에 구해둔 n-2개에서 j - 1개를 선택하게 되는것이고, 
마지막 색을 선택하지 않는다면, n-1개에서 j개를 선택하게 되는 두가지 경우를 나타낸 것.

## 또다른 풀이?
- 적록색약
BFS로도 가능
- 색상환
조합같은 문제 같음. 수학적으로 풀 수도 있지 않을까..?